### PR TITLE
feat: Implement the missing docker-compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ smoke-tests:
 	kxgr pull --verbose --group group1 --all
 	kxgr pull --verbose --group group1
 	kxgr pull --verbose --group group1 --services service1-1
-	kxgr start --verbose --group group1 --all --options -d
-	kxgr restart --verbose --group group1 --all --options -d
+	kxgr ext start --verbose --group group1 --all --options -d
+	kxgr ext restart --verbose --group group1 --all --options -d
 	kxgr exec --verbose --group group1 --service service1-1 --options -T --cmd env
 	kxgr stop --verbose --group group1 --all
 	kxgr run --verbose --group group1 --service service1-1 --options -T --cmd env
@@ -81,8 +81,8 @@ smoke-tests:
 	kxgr pull --verbose --group group2 --all
 	kxgr pull --verbose --group group2
 	kxgr pull --verbose --group group2 --services service2-1
-	kxgr start --verbose --group group2 --all --options -d
-	kxgr restart --verbose --group group2 --all --options -d
+	kxgr ext start --verbose --group group2 --all --options -d
+	kxgr ext restart --verbose --group group2 --all --options -d
 	kxgr exec --verbose --group group2 --service service2-1 --options -T --cmd env
 	kxgr stop --verbose --group group2 --all
 	kxgr run --verbose --group group2 --service service2-1 --options -T --cmd env
@@ -94,8 +94,8 @@ smoke-tests:
 	kxgr pull --verbose --group group-mix --all
 	kxgr pull --verbose --group group-mix
 	kxgr pull --verbose --group group-mix --services service1-1,service2-1
-	kxgr start --verbose --group group-mix --all --options -d
-	kxgr restart --verbose --group group-mix --all --options -d
+	kxgr ext start --verbose --group group-mix --all --options -d
+	kxgr ext restart --verbose --group group-mix --all --options -d
 	kxgr exec --verbose --group group-mix --service service2-1 --options -T --cmd env
 	kxgr stop --verbose --group group-mix --all
 	kxgr run --verbose --group group-mix --service service2-1 --options -T --cmd env

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ build:
 .ONESHELL:
 .PHONY: smoke-tests
 smoke-tests:
+	# note: don't change the order of the commands heres
+
 	set -ex
 	# group 1
 	kxgr --help
@@ -74,6 +76,7 @@ smoke-tests:
 	kxgr stop --verbose --group group1 --all
 	kxgr run --verbose --group group1 --service service1-1 --options -T --cmd env
 	kxgr down --verbose --group group1
+
 	# group 2
 	kxgr build --verbose --group group2 --all
 	kxgr build --verbose --group group2
@@ -87,6 +90,7 @@ smoke-tests:
 	kxgr stop --verbose --group group2 --all
 	kxgr run --verbose --group group2 --service service2-1 --options -T --cmd env
 	kxgr down --verbose --group group2
+
 	# group mix
 	kxgr build --verbose --group group-mix --all
 	kxgr build --verbose --group group-mix
@@ -100,3 +104,29 @@ smoke-tests:
 	kxgr stop --verbose --group group-mix --all
 	kxgr run --verbose --group group-mix --service service2-1 --options -T --cmd env
 	kxgr down --verbose --group group-mix
+
+	# general tests main profile/plugins
+	kxgr build --verbose --group group1
+	kxgr config --verbose --group group1
+	kxgr create --verbose --group group1
+	kxgr ext start --verbose --group group1 --options -d
+	kxgr ext restart --verbose --group group1 --options -d
+	kxgr exec --verbose --group group1 --service service1-1 --options -T --cmd env
+	kxgr images --verbose --group group1
+	kxgr logs --verbose --group group1
+	kxgr port --verbose --group group1
+	kxgr ps --verbose --group group1
+	kxgr pull --verbose --group group1
+	kxgr push --verbose --group group1
+	kxgr run --verbose --group group1 --service service1-1 --options -T --cmd env
+	kxgr top --verbose --group group1
+	kxgr up --verbose --group group1 --options -d
+	kxgr version --verbose --group group1
+	kxgr events --verbose --group group1 --options --json --dry-run
+	# keep these ones at the end
+	kxgr pause --verbose --group group1
+	kxgr unpause --verbose --group group1
+	kxgr kill --verbose --group group1
+	kxgr stop --verbose --group group1
+	kxgr rm --verbose --group group1 --options --force
+	kxgr down --verbose --group group1

--- a/containers_sugar/sugar.py
+++ b/containers_sugar/sugar.py
@@ -234,7 +234,6 @@ class SugarMain(SugarBase):
     This is the docker-compose commands that is implemented:
 
         build [options] [SERVICE...]
-        bundle [options]
         config [options]
         create [options] [SERVICE...]
         down [options] [--rmi type] [--volumes] [--remove-orphans]
@@ -252,7 +251,6 @@ class SugarMain(SugarBase):
         rm [options] [-f | -s] [SERVICE...]
         run [options] [-p TARGET...] [-v VOLUME...] [-e KEY=VAL...]
             [-l KEY=VAL...] SERVICE [COMMAND] [ARGS...]
-        scale [options] [SERVICE=NUM...]
         start [options] [SERVICE...]
         stop [options] [SERVICE...]
         top [options] [SERVICE...]
@@ -264,7 +262,6 @@ class SugarMain(SugarBase):
 
     actions: List[str] = [
         'build',
-        'bundle',
         'config',
         'create',
         'down',
@@ -281,7 +278,6 @@ class SugarMain(SugarBase):
         'restart',
         'rm',
         'run',
-        'scale',
         'start',
         'stop',
         'top',
@@ -296,9 +292,6 @@ class SugarMain(SugarBase):
     # container commands
     def _build(self):
         self._call_compose_app('build', services=self.service_names)
-
-    def _bundle(self):
-        self._call_compose_app('bundle')
 
     def _config(self):
         self._call_compose_app('config')
@@ -372,9 +365,6 @@ class SugarMain(SugarBase):
 
         self._call_compose_app('run', services=[self.args.get('service')])
 
-    def _scale(self):
-        self._call_compose_app('scale', services=self.service_names)
-
     def _start(self):
         self._call_compose_app('start', services=self.service_names)
 
@@ -391,7 +381,7 @@ class SugarMain(SugarBase):
         self._call_compose_app('up', services=self.service_names)
 
     def _version(self):
-        self._call_compose_app('stop', services=self.service_names)
+        self._call_compose_app('version', services=self.service_names)
 
 
 class SugarExt(SugarMain):

--- a/containers_sugar/sugar.py
+++ b/containers_sugar/sugar.py
@@ -229,74 +229,82 @@ class SugarBase(PrintPlugin):
         return getattr(self, f'_{action.replace("-", "_")}')()
 
 
-class SugarExt(SugarBase):
-    actions: List[str] = []
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def _wait(self):
-        self._print_error('[EE] `wait` not implemented yet.')
-        os._exit(1)
-
-
 class SugarMain(SugarBase):
     """
     This is the docker-compose commands that is implemented:
 
-    docker-compose build [options] [SERVICE...]
-    docker-compose bundle [options]
-    docker-compose config [options]
-    docker-compose create [options] [SERVICE...]
-    docker-compose down [options] [--rmi type] [--volumes] [--remove-orphans]
-    docker-compose events [options] [SERVICE...]
-    docker-compose exec [options] SERVICE COMMAND [ARGS...]
-    docker-compose images [options] [SERVICE...]
-    docker-compose kill [options] [SERVICE...]
-    docker-compose logs [options] [SERVICE...]
-    docker-compose pause [options] SERVICE...
-    docker-compose port [options] SERVICE PRIVATE_PORT
-    docker-compose ps [options] [SERVICE...]
-    docker-compose pull [options] [SERVICE...]
-    docker-compose push [options] [SERVICE...]
-    docker-compose restart [options] [SERVICE...]
-    docker-compose rm [options] [-f | -s] [SERVICE...]
-    docker-compose run [options] [-p TARGET...] [-v VOLUME...] [-e KEY=VAL...]
-        [-l KEY=VAL...] SERVICE [COMMAND] [ARGS...]
-    docker-compose scale [options] [SERVICE=NUM...]
-    docker-compose start [options] [SERVICE...]
-    docker-compose stop [options] [SERVICE...]
-    docker-compose top [options] [SERVICE...]
-    docker-compose unpause [options] SERVICE...
-    docker-compose up [options] [--scale SERVICE=NUM...] [--no-color]
-        [--quiet-pull] [SERVICE...]
-    docker-compose version [options]
+        build [options] [SERVICE...]
+        bundle [options]
+        config [options]
+        create [options] [SERVICE...]
+        down [options] [--rmi type] [--volumes] [--remove-orphans]
+        events [options] [SERVICE...]
+        exec [options] SERVICE COMMAND [ARGS...]
+        images [options] [SERVICE...]
+        kill [options] [SERVICE...]
+        logs [options] [SERVICE...]
+        pause [options] SERVICE...
+        port [options] SERVICE PRIVATE_PORT
+        ps [options] [SERVICE...]
+        pull [options] [SERVICE...]
+        push [options] [SERVICE...]
+        restart [options] [SERVICE...]
+        rm [options] [-f | -s] [SERVICE...]
+        run [options] [-p TARGET...] [-v VOLUME...] [-e KEY=VAL...]
+            [-l KEY=VAL...] SERVICE [COMMAND] [ARGS...]
+        scale [options] [SERVICE=NUM...]
+        start [options] [SERVICE...]
+        stop [options] [SERVICE...]
+        top [options] [SERVICE...]
+        unpause [options] SERVICE...
+        up [options] [--scale SERVICE=NUM...] [--no-color]
+            [--quiet-pull] [SERVICE...]
+        version [options]
     """
 
     actions: List[str] = [
         'build',
+        'bundle',
         'config',
+        'create',
         'down',
+        'events',
         'exec',
-        'get-ip',
+        'images',
+        'kill',
         'logs',
+        'pause',
+        'port',
+        'ps',
         'pull',
-        'run',
+        'push',
         'restart',
+        'rm',
+        'run',
+        'scale',
         'start',
         'stop',
-        'wait',
+        'top',
+        'unpause',
+        'up',
+        'version',
     ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     # container commands
+    def _build(self):
+        self._call_compose_app('build', services=self.service_names)
+
+    def _bundle(self):
+        self._call_compose_app('bundle')
+
     def _config(self):
         self._call_compose_app('config')
 
-    def _build(self):
-        self._call_compose_app('build', services=self.service_names)
+    def _create(self):
+        self._call_compose_app('create', services=self.service_names)
 
     def _down(self):
         if self.args.get('all') or self.args.get('services'):
@@ -312,6 +320,9 @@ class SugarMain(SugarBase):
             services=[],
         )
 
+    def _events(self):
+        self._call_compose_app('events', services=self.service_names)
+
     def _exec(self):
         if not self.args.get('service'):
             self._print_error(
@@ -321,22 +332,36 @@ class SugarMain(SugarBase):
 
         self._call_compose_app('exec', services=[self.args.get('service')])
 
-    def _get_ip(self):
-        self._print_error('[EE] `get-ip` mot implemented yet.')
-        os._exit(1)
+    def _images(self):
+        self._call_compose_app('images', services=self.service_names)
+
+    def _kill(self):
+        self._call_compose_app('kill', services=self.service_names)
 
     def _logs(self):
         self._call_compose_app('logs', services=self.service_names)
 
+    def _pause(self):
+        self._call_compose_app('pause', services=self.service_names)
+
+    def _port(self):
+        # TODO: check how private port could be passed
+        self._call_compose_app('port', services=self.service_names)
+
+    def _ps(self):
+        self._call_compose_app('ps', services=self.service_names)
+
     def _pull(self):
         self._call_compose_app('pull', services=self.service_names)
 
+    def _push(self):
+        self._call_compose_app('push', services=self.service_names)
+
     def _restart(self):
-        options_args = self.options_args
-        self.options_args = []
-        self._stop()
-        self.options_args = options_args
-        self._start()
+        self._call_compose_app('restart', services=self.service_names)
+
+    def _rm(self):
+        self._call_compose_app('rm', services=self.service_names)
 
     def _run(self):
         if not self.args.get('service'):
@@ -347,11 +372,48 @@ class SugarMain(SugarBase):
 
         self._call_compose_app('run', services=[self.args.get('service')])
 
+    def _scale(self):
+        self._call_compose_app('scale', services=self.service_names)
+
     def _start(self):
-        self._call_compose_app('up', services=self.service_names)
+        self._call_compose_app('start', services=self.service_names)
 
     def _stop(self):
         self._call_compose_app('stop', services=self.service_names)
+
+    def _top(self):
+        self._call_compose_app('top', services=self.service_names)
+
+    def _unpause(self):
+        self._call_compose_app('unpause', services=self.service_names)
+
+    def _up(self):
+        self._call_compose_app('up', services=self.service_names)
+
+    def _version(self):
+        self._call_compose_app('stop', services=self.service_names)
+
+
+class SugarExt(SugarMain):
+    def __init__(self, *args, **kwargs):
+        self.actions += [
+            'start',
+            'get-ip',
+            'wait',
+        ]
+
+        super().__init__(*args, **kwargs)
+
+    def _start(self):
+        self._up()
+
+    def _get_ip(self):
+        self._print_error('[EE] `get-ip` mot implemented yet.')
+        os._exit(1)
+
+    def _wait(self):
+        self._print_error('[EE] `wait` not implemented yet.')
+        os._exit(1)
 
 
 class Sugar(SugarBase, PrintPlugin):


### PR DESCRIPTION
Implement the missing docker-compose command in the main profile/plugin.
This is the complete list of the supported commands:

```
      build [options] [SERVICE...]
      config [options]
      create [options] [SERVICE...]
      down [options] [--rmi type] [--volumes] [--remove-orphans]
      events [options] [SERVICE...]
      exec [options] SERVICE COMMAND [ARGS...]
      images [options] [SERVICE...]
      kill [options] [SERVICE...]
      logs [options] [SERVICE...]
      pause [options] SERVICE...
      port [options] SERVICE PRIVATE_PORT
      ps [options] [SERVICE...]
      pull [options] [SERVICE...]
      push [options] [SERVICE...]
      restart [options] [SERVICE...]
      rm [options] [-f | -s] [SERVICE...]
      run [options] [-p TARGET...] [-v VOLUME...] [-e KEY=VAL...]
          [-l KEY=VAL...] SERVICE [COMMAND] [ARGS...]
      start [options] [SERVICE...]
      stop [options] [SERVICE...]
      top [options] [SERVICE...]
      unpause [options] SERVICE...
      up [options] [--scale SERVICE=NUM...] [--no-color]
          [--quiet-pull] [SERVICE...]
      version [options]
```

the previous commands for start and restart was moved to ext profile/plugin, so in order to use
the same behavior it is necessary to run `kxgr ext start` or `kxgr ext restart`.

In follow-up works, more commands will be added to ext profile/plugin and maybe user defined "function" profile would be added in the future.